### PR TITLE
bionic: Use legacy pthread_mutex_init() behavior on pre-P API levels

### DIFF
--- a/libc/bionic/pthread_mutex.cpp
+++ b/libc/bionic/pthread_mutex.cpp
@@ -526,7 +526,8 @@ int pthread_mutex_init(pthread_mutex_t* mutex_interface, const pthread_mutexattr
         return EINVAL;
     }
 
-    if (((*attr & MUTEXATTR_PROTOCOL_MASK) >> MUTEXATTR_PROTOCOL_SHIFT) == PTHREAD_PRIO_INHERIT) {
+    if (((*attr & MUTEXATTR_PROTOCOL_MASK) >> MUTEXATTR_PROTOCOL_SHIFT) == PTHREAD_PRIO_INHERIT
+            && bionic_get_application_target_sdk_version() >= __ANDROID_API_P__) {
 #if !defined(__LP64__)
         if (state & MUTEX_SHARED_MASK) {
             return EINVAL;


### PR DESCRIPTION
* Google's changes to pthread_mutex_init is breaking RIL
  on certain Samsung devices like klte and hlte
* To resolve this, add a check for their new additions
  to only apply the new behavior for P and higher APIs

Change-Id: I41335c5c436fa28a66d044e6634466556dfd7f95