### PR TITLE
Revert "linker: Make platform text relocations denial optional"

### DIFF
--- a/linker/Android.bp
+++ b/linker/Android.bp
@@ -167,9 +167,6 @@ cc_binary {
             cppflags: ["-DUSE_LD_CONFIG_FILE"],
         },
         lineage: {
-            needs_text_relocations: {
-                cppflags: ["-DTARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS"],
-            },
             target_process_sdk_version_override: {
                 cppflags: ["-DSDK_VERSION_OVERRIDES=\"%s\""],
             },

--- a/linker/linker.cpp
+++ b/linker/linker.cpp
@@ -3621,12 +3621,7 @@ bool soinfo::link_image(const soinfo_list_t& global_group, const soinfo_list_t& 
   if (has_text_relocations) {
     // Fail if app is targeting M or above.
     int app_target_api_level = get_application_target_sdk_version();
-#if defined(TARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS)
-    if (app_target_api_level != __ANDROID_API__
-        && app_target_api_level >= __ANDROID_API_M__) {
-#else
     if (app_target_api_level >= __ANDROID_API_M__) {
-#endif
       DL_ERR_AND_LOG("\"%s\" has text relocations (https://android.googlesource.com/platform/"
                      "bionic/+/master/android-changes-for-ndk-developers.md#Text-Relocations-"
                      "Enforced-for-API-level-23)", get_realpath());


### PR DESCRIPTION
* The per-process API level override will take care of this

This reverts commit 917e59c19fbeb9b85c21a1e4b7bebf5048ce8efc.

Change-Id: I526885fe77f0bba573218d550849b6cd0e425df0