### PR TITLE
bionic: Prefer /sbin/sh if it exists

### DIFF
--- a/libc/bionic/__bionic_get_shell_path.cpp
+++ b/libc/bionic/__bionic_get_shell_path.cpp
@@ -29,11 +29,18 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/cdefs.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #define VENDOR_PREFIX "/vendor/"
 
 static const char* init_sh_path() {
+  /* Prefer /sbin/sh */
+  struct stat st;
+  if (stat("/sbin/sh", &st) == 0) {
+    return "/sbin/sh";
+  }
+
   /* If the device is not treble enabled, return the path to the system shell.
    * Vendor code, on non-treble enabled devices could use system() / popen()
    * with relative paths for executables on /system. Since /system will not be


### PR DESCRIPTION
Prefer /sbin/sh because in recovery (or generally, not booted to the
main Android system), the system shell and its associated rc file
should not be used.  One reason is that TMPDIR is set to a path that
will likely not be mounted (/data/local/tmp).

Change-Id: I3ec22aa2537a7795baae6e782134d3b05f4b3ace